### PR TITLE
Fix starting tg_bot container after rabbit

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       image: rabbitmq:3.13.7-management-alpine
       container_name: 'rabbitmq'
       healthcheck:
-        test: rabbitmq-diagnostics -q ping
+        test: rabbitmq-diagnostics -q check_port_connectivity
         interval: 5s
         timeout: 5s
         retries: 5


### PR DESCRIPTION
- it was starting when rabbitmq wasn't ready to open connections