### PR TITLE
Keep the bot connection open

### DIFF
--- a/yt_playlist_bot/event_listeners/link_event_listener.py
+++ b/yt_playlist_bot/event_listeners/link_event_listener.py
@@ -1,6 +1,8 @@
 import asyncio
 import typing
+from functools import partial
 
+import aiogram
 import structlog
 from aio_pika.abc import AbstractQueue
 
@@ -20,11 +22,12 @@ async def _process_message(
     message_id: str,
     message_body: dict[str, typing.Any],
     routing_key: str,
+    bot: aiogram.Bot,
 ) -> None:
     """Check routing key and choose corresponding message processor."""
     if routing_key != settings.GET_VIDEO_FROM_PLAYLIST_EVENT:
         raise KeyError("Unknown routing key.")
-    await process_get_a_video_events(event_loop, message_body)
+    await process_get_a_video_events(event_loop, message_body, bot)
 
 
 async def main(event_loop: asyncio.AbstractEventLoop) -> None:
@@ -50,11 +53,18 @@ async def main(event_loop: asyncio.AbstractEventLoop) -> None:
         routing_key=settings.GET_VIDEO_FROM_PLAYLIST_EVENT,
     )
 
+    bot = aiogram.Bot(token=settings.BOT_TOKEN)
+
     try:
-        await consumer(queue=queue, event_loop=event_loop, callback_func=_process_message)
+        await consumer(
+            queue=queue,
+            event_loop=event_loop,
+            callback_func=partial(_process_message, bot=bot),
+        )
     except Exception as exc:
         logger.error("Consumer closed unexpectedly.", exc=exc)
     finally:
         logger.info("Terminating consumer...")
         await channel.close()
         await connection.close()
+        await bot.close()

--- a/yt_playlist_bot/event_processors/youtube_playlist_link_processor.py
+++ b/yt_playlist_bot/event_processors/youtube_playlist_link_processor.py
@@ -1,11 +1,11 @@
 import asyncio
 import typing
 
+import aiogram
 import structlog
-from aiogram import Bot
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
-from yt_playlist_bot import constants, settings
+from yt_playlist_bot import constants
 from yt_playlist_bot.link_processor.main import process_link
 from yt_playlist_bot.tg_bot.callbacks import OneMoreVideoCallback
 
@@ -26,6 +26,7 @@ def _extract_playlist_id(playlist_link: str) -> str:
 async def process_get_a_video_events(
     event_loop: asyncio.AbstractEventLoop,
     message_body: dict[str, typing.Any],
+    bot: aiogram.Bot,
 ) -> None:
     link = await event_loop.run_in_executor(
         None,
@@ -35,9 +36,6 @@ async def process_get_a_video_events(
 
     msg_text = f"There is your random video from your playlist: {link}"
 
-    # todo: find a way not to initialize it every time
-    # maybe to keep an open bot in another consumer and send message via rabbitmq there
-    bot = Bot(token=settings.BOT_TOKEN)
     chat_id = message_body["requester_telegram_id"]
     telegram_message_id = message_body["telegram_message_id"]
 
@@ -62,5 +60,3 @@ async def process_get_a_video_events(
     )
 
     logger.debug("Sent a link to a random video back to the chat", chat_id=chat_id)
-    await bot.session.close()
-    logger.debug("Closed the bot connection for the link processor.")

--- a/yt_playlist_bot/rabbit/consumer.py
+++ b/yt_playlist_bot/rabbit/consumer.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-import typing
+import typing as tp
 from asyncio import AbstractEventLoop
 
 import structlog
@@ -12,14 +12,15 @@ logger = structlog.getLogger(__name__)
 PREFETCH_COUNT = 100
 
 
-class CallbackType(typing.Protocol):
+class CallbackType(tp.Protocol):
     def __call__(
         self,
         event_loop: AbstractEventLoop,
         message_id: str,
-        message_body: dict[typing.Any, typing.Any],
+        message_body: dict[tp.Any, tp.Any],
         routing_key: str,
-    ) -> typing.Awaitable[None]:
+        **kwargs: tp.Any,
+    ) -> tp.Awaitable[None]:
         """A signature of a function that will be called to process a rabbit message."""
         pass
 


### PR DESCRIPTION
- we have a separate bot instance to send a message back to user with the random video from his YouTube list. Previously, this bot connection used to be open to send the link and then closed. Now, it should stay open for the whole time the consumer is running to avoid opening/closing connection to telegram servers all the time