### PR TITLE
Substitute not maintained and broken youtube lib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
-module = "pytube"
+module = "pytubefix"
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiogram~=3.14.0
 aio-pika~=9.4.3
-pytube~=15.0.0
+pytubefix==9.3.0
 structlog~=24.4.0

--- a/yt_playlist_bot/link_processor/main.py
+++ b/yt_playlist_bot/link_processor/main.py
@@ -2,7 +2,7 @@ import argparse
 import random
 
 import structlog
-from pytube import Playlist
+from pytubefix import Playlist
 
 from yt_playlist_bot import constants
 

--- a/yt_playlist_bot/rabbit/consumer.py
+++ b/yt_playlist_bot/rabbit/consumer.py
@@ -64,6 +64,7 @@ async def consumer(
                     continue
 
                 try:
+                    logger.info("Calling callback function")
                     await callback_func(
                         event_loop=event_loop,
                         message_id=message.message_id,
@@ -74,7 +75,7 @@ async def consumer(
                     logger.error(
                         "An error occurred while processing the message.",
                         request_uuid=message.correlation_id,
-                        exc=exc,
+                        exc_info=True,
                     )
                     await message.nack(requeue=False)
                     continue


### PR DESCRIPTION
- use pytubefix lib which is fork of pytube. The latter hasn't been maintained for two years as of now and stopped working probably because YouTube changed the API recently
- fix showing an error if processing Rabbit message fails (now logs will contain the traceback of an error so developer could see what went wrong)